### PR TITLE
FIX: Include unique file ID in key derivation

### DIFF
--- a/file/random_access_file_reader.h
+++ b/file/random_access_file_reader.h
@@ -65,7 +65,8 @@ class RandomAccessFileReader : public edg::EncryptedFile {
       HistogramImpl* file_read_hist = nullptr,
       RateLimiter* rate_limiter = nullptr,
       const std::vector<std::shared_ptr<EventListener>>& listeners = {})
-      : file_(std::move(raf)),
+      : EncryptedFile(_file_name),
+        file_(std::move(raf)),
         file_name_(std::move(_file_name)),
         env_(env),
         stats_(stats),
@@ -85,7 +86,7 @@ class RandomAccessFileReader : public edg::EncryptedFile {
 #endif
   }
 
-  RandomAccessFileReader(RandomAccessFileReader&& o) ROCKSDB_NOEXCEPT {
+  RandomAccessFileReader(RandomAccessFileReader&& o) ROCKSDB_NOEXCEPT : EncryptedFile(std::move(o)) {
     *this = std::move(o);
   }
 

--- a/file/sequence_file_reader.h
+++ b/file/sequence_file_reader.h
@@ -29,15 +29,16 @@ class SequentialFileReader : public edg::EncryptedFile {
  public:
   explicit SequentialFileReader(std::unique_ptr<FSSequentialFile>&& _file,
                                 const std::string& _file_name)
-      : file_(std::move(_file)), file_name_(_file_name) {}
+      : EncryptedFile(_file_name), file_(std::move(_file)), file_name_(_file_name) {}
 
   explicit SequentialFileReader(std::unique_ptr<FSSequentialFile>&& _file,
                                 const std::string& _file_name,
                                 size_t _readahead_size)
-      : file_(NewReadaheadSequentialFile(std::move(_file), _readahead_size)),
+      : EncryptedFile(_file_name),
+        file_(NewReadaheadSequentialFile(std::move(_file), _readahead_size)),
         file_name_(_file_name) {}
 
-  SequentialFileReader(SequentialFileReader&& o) ROCKSDB_NOEXCEPT {
+  SequentialFileReader(SequentialFileReader&& o) ROCKSDB_NOEXCEPT : EncryptedFile(std::move(o)) {
     *this = std::move(o);
   }
 

--- a/file/writable_file_writer.h
+++ b/file/writable_file_writer.h
@@ -83,7 +83,8 @@ class WritableFileWriter : public edg::EncryptedWritableFile {
       Statistics* stats = nullptr,
       const std::vector<std::shared_ptr<EventListener>>& listeners = {},
       FileChecksumFunc* checksum_func = nullptr)
-      : writable_file_(std::move(file)),
+      : EncryptedWritableFile(_file_name),
+        writable_file_(std::move(file)),
         file_name_(_file_name),
         env_(env),
         buf_(),

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -3676,12 +3676,12 @@ TEST_F(HarnessTest, FooterTests) {
     BlockHandle meta_index(10, 5), index(20, 15);
     footer.set_metaindex_handle(meta_index);
     footer.set_index_handle(index);
-    edg::EncryptedWritableFile fw;
+    edg::EncryptedWritableFile fw(MakeTableFileName(123));
     fw.CreateKey();
     footer.EncodeTo(&encoded, fw);
     Footer decoded_footer;
     Slice encoded_slice(encoded);
-    edg::EncryptedFile fr;
+    edg::EncryptedFile fr(MakeTableFileName(123));
     decoded_footer.DecodeFrom(&encoded_slice, fr);
     ASSERT_EQ(decoded_footer.table_magic_number(), 0);
     ASSERT_EQ(decoded_footer.metaindex_handle().offset(), meta_index.offset());
@@ -3793,6 +3793,23 @@ TEST_F(HarnessTest, FooterTests) {
     ASSERT_EQ(decoded_footer.version(), 2U);
   }
 #endif
+}
+
+TEST_F(HarnessTest, FooterTestsWrongFileName) {
+  // MODIFIED TEST: encode/decode encrypted footer
+  std::string encoded;
+  Footer footer;
+  BlockHandle meta_index(10, 5), index(20, 15);
+  footer.set_metaindex_handle(meta_index);
+  footer.set_index_handle(index);
+  edg::EncryptedWritableFile fw(MakeTableFileName(123));
+  fw.CreateKey();
+  footer.EncodeTo(&encoded, fw);
+  Footer decoded_footer;
+  Slice encoded_slice(encoded);
+  edg::EncryptedFile fr(MakeTableFileName(124));
+  // the following should fail, because we have the wrong file ID
+  ASSERT_NOK(decoded_footer.DecodeFrom(&encoded_slice, fr));
 }
 
 class IndexBlockRestartIntervalTest


### PR DESCRIPTION
Other than planned, we so far did not include the files' unique IDs in the the HKDF key derivation. This allowed an attacker to swap encrypted files on disk.

We now use `ParseFileName()` to get a file's unique ID and use it as `info` in HKDF. 

For reference: In RocksDB, files get a unique ID. IDs are unique across file types. RocksDB maintains an atomic counter for this: `VersionSet::next_file_number_`