### PR TITLE
SECURITY-FIX: Add encryption for option files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,7 @@ set(SOURCES
         file/sst_file_manager_impl.cc
         file/writable_file_writer.cc
         file/encrypted_file.cc
+        file/encrypted_file_util.cc
         logging/auto_roll_logger.cc
         logging/event_logger.cc
         logging/log_buffer.cc

--- a/db/log_reader.cc
+++ b/db/log_reader.cc
@@ -360,7 +360,7 @@ bool Reader::DecryptRecord() {
   auto payload = edgeless::Buffer(
       const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(start_payload)),
       header.meta.length);
-  auto key = file_->GetKey();
+  decltype(auto) key = file_->GetKey();
   const auto succ = key->Decrypt(payload,
                                  edgeless::ToCBuffer(index_),       // iv
                                  edgeless::ToCBuffer(header.meta),  // aad

--- a/file/encrypted_file_util.cc
+++ b/file/encrypted_file_util.cc
@@ -1,0 +1,81 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "encrypted_file_util.h"
+
+#include <limits>
+#include <string>
+
+using namespace std;
+using namespace edgeless;
+
+namespace rocksdb {
+
+#pragma pack(push, 1)
+struct EncRecordHeader {
+  crypto::Tag tag;
+  uint32_t size;
+};
+#pragma pack(pop)
+
+// Writes an encrypted record to the given file. Takes care of all formatting,
+// like writing a nonce.
+bool WriteEncRecord(WritableFileWriter& file, const Slice& record,
+                    const uint64_t iv) {
+  if (record.size() > numeric_limits<decltype(EncRecordHeader::size)>::max())
+    return false;
+
+  decltype(auto) key = file.GetKey();
+  // do we have a key yet?
+  if (!key.has_value()) {
+    assert(!file.GetFileSize());
+    file.CreateKey();
+    // write nonce to beginning of file
+    if (!file.Append(file.GetNonce()).ok()) return false;
+  }
+
+  vector<uint8_t> ct(record.size());
+  EncRecordHeader header{.size = static_cast<uint32_t>(record.size())};
+  key->Encrypt(
+      CBuffer{reinterpret_cast<const uint8_t*>(record.data()), record.size()},
+      ToCBuffer(iv), header.tag, ct);
+  if (!file.Append(ToSliceRaw(header)).ok()) return false;
+  if (!file.Append(ToSlice(ct)).ok()) return false;
+  return true;
+}
+
+optional<string> ReadEncRecord(SequentialFileReader& file, const uint64_t iv) {
+  decltype(auto) key = file.GetKey();
+  // do we have a key yet?
+  if (!key.has_value()) {
+    // read nonce from beginnig of file
+    array<uint8_t, EncryptedFile::kDefaultNonceSize> nonce;
+    Slice slice;
+    if (!file.Read(sizeof(nonce), &slice, reinterpret_cast<char*>(nonce.data()))
+             .ok())
+      return {};
+    file.CreateKey(nonce);
+  }
+  EncRecordHeader header;
+  Slice slice;
+  if (!file.Read(sizeof(header), &slice, reinterpret_cast<char*>(&header)).ok())
+    return {};
+
+  string record;
+  // the size field in the header is untrusted, we're thus being cautious...
+  try {
+    record.resize(header.size);
+  } catch (const bad_alloc&) {
+    return {};
+  }
+  if (!file.Read(header.size, &slice, record.data()).ok()) return {};
+
+  Buffer buf{reinterpret_cast<uint8_t*>(record.data()), record.size()};
+  if (!key->Decrypt(buf, ToCBuffer(iv), header.tag, buf)) return {};
+  return record;
+}
+
+}  // namespace rocksdb

--- a/file/encrypted_file_util.cc
+++ b/file/encrypted_file_util.cc
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace edgeless;
 
-namespace rocksdb {
+namespace rocksdb::edg {
 
 #pragma pack(push, 1)
 struct EncRecordHeader {

--- a/file/encrypted_file_util.h
+++ b/file/encrypted_file_util.h
@@ -1,0 +1,33 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "file/sequence_file_reader.h"
+#include "file/writable_file_writer.h"
+
+namespace rocksdb::edg {
+
+template <typename T>
+Slice ToSliceRaw(T& o) {
+  return {reinterpret_cast<const char*>(&o), sizeof(o)};
+}
+
+inline Slice ToSlice(const edgeless::CBuffer& b) {
+  return {reinterpret_cast<const char*>(b.data()), b.size()};
+}
+
+// Writes an encrypted record to the given file. Takes care of all formatting,
+// like writing a nonce.
+bool WriteEncRecord(WritableFileWriter& file, const Slice& record,
+                    const uint64_t iv);
+
+// Reads an encrypted record from the given file. Takes care of deriving the key
+// if necessary.
+std::optional<std::string> ReadEncRecord(SequentialFileReader& file,
+                                         const uint64_t iv);
+
+}  // namespace rocksdb

--- a/file/file_id.h
+++ b/file/file_id.h
@@ -1,0 +1,31 @@
+// Copyright (c) Edgeless Systems GmbH.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <optional>
+#include <filesystem>
+
+#include "file/filename.h"
+
+namespace rocksdb::edg {
+
+// Parse unique ID from file path
+inline std::optional<uint64_t> FileIDFromPath(const std::string& file_path) {
+  // Parse the file's unique ID from the path. RocksDB generates file paths
+  // using the functions in filename.h
+
+  // TODO: this could be optimized by maintaining a global mapping from file
+  // path to unique ID in filename.cc
+  const auto path = std::filesystem::path(file_path);
+  if (!path.has_filename()) return {};
+  const auto file_name = path.filename().generic_string();
+
+  FileType type;
+  WalFileType log_type;
+  uint64_t unique_id;
+  if (!ParseFileName(file_name, &unique_id, &type, &log_type)) return {};
+  return unique_id;
+}
+}  // namespace rocksdb

--- a/table/format.cc
+++ b/table/format.cc
@@ -170,7 +170,7 @@ void Footer::EncodeTo(std::string* dst, edg::EncryptedWritableFile& file) const 
   file.GetKey()->Encrypt(kIv, handles, tag);
   // Write the nonce to the end
   const auto nonce = file.GetNonce();
-  std::copy_n(nonce->data(), sizeof(*nonce), tag.data() + tag.size());
+  std::copy_n(nonce.data(), nonce.size(), tag.data() + tag.size());
 }
 
 Status Footer::DecodeFrom(Slice* input, edg::EncryptedFile& file) {

--- a/table/format.h
+++ b/table/format.h
@@ -158,7 +158,7 @@ class Footer {
   // EDG: length of two encoded block handles and one AES-GCM tag
   static constexpr size_t kSize = kSizeHandles +
                                   edgeless::crypto::Key::kSizeTag +
-                                  sizeof(edg::EncryptedFile::Nonce);
+                                  edg::EncryptedFile::kDefaultNonceSize;
 
   static const uint64_t kInvalidTableMagicNumber = 0;
 

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -1492,19 +1492,21 @@ TEST_F(BackupableDBTest, GarbageCollectionBeforeBackup) {
   OpenDBAndBackupEngine(true);
 
   backup_chroot_env_->CreateDirIfMissing(backupdir_ + "/shared");
-  std::string file_five = backupdir_ + "/shared/000007.sst";
+  // MODIFIED TEST: we switched to using one file ID instead of two file IDs for OPTIONS updates.
+  // Thus, we need to reduce this from 7 to 6 here.
+  std::string file_five = backupdir_ + "/shared/000006.sst";
   std::string file_five_contents = "I'm not really a sst file";
-  // this depends on the fact that 00007.sst is the first file created by the DB
+  // this depends on the fact that 00006.sst is the first file created by the DB
   ASSERT_OK(file_manager_->WriteToFile(file_five, file_five_contents));
 
   FillDB(db_.get(), 0, 100);
-  // backup overwrites file 000007.sst
+  // backup overwrites file 000006.sst
   ASSERT_TRUE(backup_engine_->CreateNewBackup(db_.get(), true).ok());
 
   std::string new_file_five_contents;
   ASSERT_OK(ReadFileToString(backup_chroot_env_.get(), file_five,
                              &new_file_five_contents));
-  // file 000007.sst was overwritten
+  // file 000006.sst was overwritten
   ASSERT_TRUE(new_file_five_contents != file_five_contents);
 
   CloseDBAndBackupEngine();


### PR DESCRIPTION
RocksDB stores its current configuration options in files. These are recovered after a restart. So far we did not encrypt option files. This allowed an external attacker to modify options when restarting. This is could be a severe vulnerability.

In essence, we now encrypt options files in one go using our existing mechanisms in `options_parser.cc`. In addition, `DBImpl::RenameTempFileToOptionsFile` in `db_impl.cc` required some slight modification: the function obtains a unique file ID for writing options to a temp file. It then obtains another ID to make the file non-temp. This clashed with our approach of deriving file encryption keys from IDs. Therefore, we switched the code to only use one ID.

The rest of the PR is refactoring to facilitate the above changes.